### PR TITLE
Add header line when writing to cookies.txt

### DIFF
--- a/lib/http/cookie_jar.rb
+++ b/lib/http/cookie_jar.rb
@@ -163,7 +163,7 @@ class HTTP::CookieJar
   # Write cookies to Mozilla cookies.txt-style IO stream and return
   # self.
   def dump_cookiestxt(io)
-    io.puts "# Netscape HTTP Cookie File"
+    io.puts "# HTTP Cookie File"
     to_a.each do |cookie|
       io.print cookie.to_cookiestxt_line
     end


### PR DESCRIPTION
Note: This pull request directly parallels sparklemotion/mechanize#293.

When Python is reading a Netscape-format cookies.txt file, it seems to require an initial line that looks like this:

```
# Netscape HTTP Cookie File
```

See [this project](https://github.com/mmorearty/mechanize-cookieproblem) for a demo that uses Mechanize.  I didn't have a chance to write a demo that uses http-cookie.
