### PR TITLE
Fix host-only cookies for unqualified hostnames

### DIFF
--- a/lib/http/cookie_jar/hash_store.rb
+++ b/lib/http/cookie_jar/hash_store.rb
@@ -67,10 +67,8 @@ class HTTP::CookieJar
     def each(uri = nil) # :yield: cookie
       now = Time.now
       if uri
-        thost = DomainName.new(uri.host)
         tpath = uri.path
         @jar.each { |domain, paths|
-          next unless thost.cookie_domain?(domain)
           paths.each { |path, hash|
             next unless HTTP::Cookie.path_match?(path, tpath)
             hash.delete_if { |name, cookie|

--- a/test/test_http_cookie_jar.rb
+++ b/test/test_http_cookie_jar.rb
@@ -139,6 +139,17 @@ module TestHTTPCookieJar
       assert_equal(0, @jar.cookies(URI('http://www.rubyforge.org/')).length)
     end
 
+    def test_host_only_with_unqualified_hostname
+      @jar.add(HTTP::Cookie.new(cookie_values(
+        :origin => 'http://localhost/', :domain => 'localhost', :for_domain => false)))
+
+      assert_equal(1, @jar.cookies(URI('http://localhost/')).length)
+
+      assert_equal(1, @jar.cookies(URI('http://Localhost/')).length)
+
+      assert_equal(1, @jar.cookies(URI('https://Localhost/')).length)
+    end
+
     def test_empty_value
       url = URI 'http://rubyforge.org/'
       values = cookie_values(:value => "")


### PR DESCRIPTION
Removed comparison against `DomainName#cookie_domain?` during filtering
of jar cookies. It was redundant considering the later call to
`HTTP::Cookie#valid_for_url?` and prevented valid host-only cookies from
being considered for unqualified hostnames (e.g. "localhost").

RFC 6265 (5.4) does not restrict host-only cookies from being used with
such unqualified names as it does for cookies with the domain attribute
set.
