### PR TITLE
More informative error message when cannot load a store

### DIFF
--- a/lib/http/cookie_jar/abstract_store.rb
+++ b/lib/http/cookie_jar/abstract_store.rb
@@ -17,8 +17,8 @@ class HTTP::CookieJar::AbstractStore
       begin
         require 'http/cookie_jar/%s_store' % symbol
         @@class_map.fetch(symbol)
-      rescue LoadError, IndexError
-        raise IndexError, 'cookie store unavailable: %s' % symbol.inspect
+      rescue LoadError, IndexError => e
+        raise IndexError, 'cookie store unavailable: %s, error: %s' % symbol.inspect, e.message
       end
     end
 


### PR DESCRIPTION
I tried to use `mozilla` store, but got the following message, that gave me no clue what's wrong:

```
      ArgumentError: cookie store unavailable: :mozilla
```

After some debugging I found that I have no `sqlite3` gem installed. But the error message should tell mi that. 

This change should help.
