### PR TITLE
Preserve quotes when parsing server cookie #11

### DIFF
--- a/lib/http/cookie.rb
+++ b/lib/http/cookie.rb
@@ -377,6 +377,13 @@ class HTTP::Cookie
     # RFC 6265 4.1.1
     # cookie-name may not match:
     # /[^\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]/
+    orig = value
+    if m = value.match(/^"(.*)"$/)
+      @raw_value = value
+      value = m[1]
+    else
+      @raw_value = nil
+    end
     @value = value
   end
 
@@ -594,7 +601,8 @@ class HTTP::Cookie
   # Returns a string for use in the Cookie header, i.e. `name=value`
   # or `name="value"`.
   def cookie_value
-    "#{@name}=#{Scanner.quote(@value)}"
+    v = ( @raw_value.nil? ? Scanner.quote(@value) : @raw_value )
+    "#{@name}=#{v}"
   end
   alias to_s cookie_value
 

--- a/lib/http/cookie/scanner.rb
+++ b/lib/http/cookie/scanner.rb
@@ -55,10 +55,14 @@ class HTTP::Cookie::Scanner < StringScanner
       case
       when scan(/[^,;"]+/)
         s << matched
-      when skip(/"/)
-        # RFC 6265 2.2
-        # A cookie-value may be DQUOTE'd.
-        s << scan_dquoted
+      when scan(/"/)
+        if s.length == 0
+          # RFC 6265 2.2
+          # A cookie-value may be DQUOTE'd.
+          s << '"' << scan_dquoted << '"'
+        else
+          s << matched
+        end
       when check(/;|#{RE_COOKIE_COMMA}/o)
         break
       else

--- a/test/test_http_cookie.rb
+++ b/test/test_http_cookie.rb
@@ -111,6 +111,7 @@ class TestHTTPCookie < Test::Unit::TestCase
     assert_equal 1, HTTP::Cookie.parse(cookie_str, uri) { |cookie|
       assert_equal 'quoted', cookie.name
       assert_equal 'value', cookie.value
+      assert_equal 'quoted="value"', cookie.cookie_value
     }.size
   end
 
@@ -430,7 +431,10 @@ class TestHTTPCookie < Test::Unit::TestCase
   def test_cookie_value
     [
       ['foo="bar  baz"', 'bar  baz'],
+      ['foo="bar  baz"', '"bar  baz"'],
       ['foo="bar\"; \"baz"', 'bar"; "baz'],
+      ['foo="bar\"; \"baz"', '"bar\"; \"baz"'],
+      ['foo="ba\"r baz"', '"ba\"r baz"'],
     ].each { |cookie_value, value|
       cookie = HTTP::Cookie.new('foo', value)
       assert_equal(cookie_value, cookie.cookie_value)
@@ -453,8 +457,14 @@ class TestHTTPCookie < Test::Unit::TestCase
 
     assert_equal 3, hash.size
 
+    parsed_pairs = [
+      ['Foo', 'value1'],
+      ['Bar', '"value 2"'],
+      ['Baz', 'value3'],
+    ]
+
     hash.each_pair { |name, value|
-      _, pvalue = pairs.assoc(name)
+      _, pvalue = parsed_pairs.assoc(name)
       assert_equal pvalue, value
     }
   end


### PR DESCRIPTION
We keep track of the original quoted value when it is already quoted,
and we avoid consider values to be quoted if they start with a quote.