### PR TITLE
Test: Avoid Ruby warning about shadowing variable names

### DIFF
--- a/test/test_http_cookie.rb
+++ b/test/test_http_cookie.rb
@@ -632,9 +632,9 @@ class TestHTTPCookie < Test::Unit::TestCase
       HTTP::Cookie.new("key", nil),
       HTTP::Cookie.new("key", :secure => true),
       HTTP::Cookie.new("key"),
-    ].each { |cookie|
-      assert_equal '', cookie.value
-      assert_equal true, cookie.expired?
+    ].each { |cookie_instance|
+      assert_equal '', cookie_instance.value
+      assert_equal true, cookie_instance.expired?
     }
 
     [
@@ -642,9 +642,9 @@ class TestHTTPCookie < Test::Unit::TestCase
       HTTP::Cookie.new("key", nil, :expires => Time.now + 3600),
       HTTP::Cookie.new("key", :expires => Time.now + 3600),
       HTTP::Cookie.new("key", :expires => Time.now + 3600, :value => nil),
-    ].each { |cookie|
-      assert_equal '', cookie.value
-      assert_equal false, cookie.expired?
+    ].each { |cookie_instance|
+      assert_equal '', cookie_instance.value
+      assert_equal false, cookie_instance.expired?
     }
   end
 
@@ -749,7 +749,7 @@ class TestHTTPCookie < Test::Unit::TestCase
     assert_equal 12, cookie.max_age
 
     cookie.max_age = -3
-    assert_equal -3, cookie.max_age
+    assert_equal(-3, cookie.max_age)
   end
 
   def test_session

--- a/test/test_http_cookie_jar.rb
+++ b/test/test_http_cookie_jar.rb
@@ -386,7 +386,7 @@ module TestHTTPCookieJar
         assert_same @jar, value
 
         @jar2.load(File.join(dir, "cookies.yml"))
-        cookies = @jar2.cookies(url).sort_by { |cookie| cookie.name }
+        cookies = @jar2.cookies(url).sort_by { |cookie_instance| cookie_instance.name }
         assert_equal(2, cookies.length)
         assert_equal('Baz', cookies[0].name)
         assert_equal(false, cookies[0].for_domain)
@@ -476,8 +476,8 @@ module TestHTTPCookieJar
       url = URI 'http://rubyforge.org/foo/'
 
       # Add one cookie with an expiration date in the future
-      cookie = HTTP::Cookie.new(cookie_values)
-      expires = cookie.expires
+      cookie1 = HTTP::Cookie.new(cookie_values)
+      expires = cookie1.expires
       s_cookie = HTTP::Cookie.new(cookie_values(:name => 'Bar',
           :expires => nil))
       cookie2 = HTTP::Cookie.new(cookie_values(:name => 'Baz',
@@ -490,7 +490,7 @@ module TestHTTPCookieJar
       ma_cookie = HTTP::Cookie.new(cookie_values(:name => 'Maxage',
           :value => 'Foo#Maxage',
           :max_age => 15000))
-      @jar.add(cookie)
+      @jar.add(cookie1)
       @jar.add(s_cookie)
       @jar.add(cookie2)
       @jar.add(h_cookie)


### PR DESCRIPTION
This PR only avoids warnings output in tests.