### PR TITLE
Support frozen string literals

### DIFF
--- a/lib/http/cookie.rb
+++ b/lib/http/cookie.rb
@@ -424,7 +424,7 @@ class HTTP::Cookie
   # Returns the domain, with a dot prefixed only if the domain flag is
   # on.
   def dot_domain
-    @for_domain ? '.' << @domain : @domain
+    @for_domain ? '.' + @domain : @domain
   end
 
   # Returns the domain attribute value as a DomainName object.

--- a/lib/http/cookie/scanner.rb
+++ b/lib/http/cookie/scanner.rb
@@ -51,7 +51,7 @@ class HTTP::Cookie::Scanner < StringScanner
   end
 
   def scan_value(comma_as_separator = false)
-    ''.tap { |s|
+    ''.dup.tap { |s|
       case
       when scan(/[^,;"]+/)
         s << matched


### PR DESCRIPTION
Fixes for running `RUBYOPT="--enable-frozen-string-literal" rake test`.