### PR TITLE
Use autoload to be threadsafe

### DIFF
--- a/lib/http/cookie_jar.rb
+++ b/lib/http/cookie_jar.rb
@@ -6,26 +6,12 @@ require 'http/cookie'
 # any particular website.
 
 class HTTP::CookieJar
-  class << self
-    def const_missing(name)
-      case name.to_s
-      when /\A([A-Za-z]+)Store\z/
-        file = 'http/cookie_jar/%s_store' % $1.downcase
-      when /\A([A-Za-z]+)Saver\z/
-        file = 'http/cookie_jar/%s_saver' % $1.downcase
-      end
-      begin
-        require file
-      rescue LoadError
-        raise NameError, 'can\'t resolve constant %s; failed to load %s' % [name, file]
-      end
-      if const_defined?(name)
-        const_get(name)
-      else
-        raise NameError, 'can\'t resolve constant %s after loading %s' % [name, file]
-      end
-    end
-  end
+  autoload :AbstractSaver, 'http/cookie_jar/abstract_saver'
+  autoload :AbstractStore, 'http/cookie_jar/abstract_store'
+  autoload :CookiestxtSaver, 'http/cookie_jar/cookiestxt_saver'
+  autoload :HashStore, 'http/cookie_jar/hash_store'
+  autoload :MozillaStore, 'http/cookie_jar/mozilla_store'
+  autoload :YamlSaver, 'http/cookie_jar/yaml_saver'
 
   attr_reader :store
 

--- a/test/test_http_cookie_jar.rb
+++ b/test/test_http_cookie_jar.rb
@@ -3,12 +3,6 @@ require 'tmpdir'
 
 module TestHTTPCookieJar
   class TestAutoloading < Test::Unit::TestCase
-    def test_nonexistent_store
-      assert_raises(NameError) {
-        HTTP::CookieJar::NonexistentStore
-      }
-    end
-
     def test_erroneous_store
       Dir.mktmpdir { |dir|
         Dir.mkdir(File.join(dir, 'http'))


### PR DESCRIPTION
The current implementation of `const_missing` is not thread safe and it triggers exceptions like:

```
NoMethodError: undefined method `implementation' for HTTP::CookieJar::AbstractStore:Class
  /app/data/bundler/ruby/2.6.0/gems/http-cookie-1.0.3/lib/http/cookie_jar.rb:38:in `get_impl'
  /app/data/bundler/ruby/2.6.0/gems/http-cookie-1.0.3/lib/http/cookie_jar.rb:74:in `initialize'
  /app/data/bundler/ruby/2.6.0/gems/rest-client-2.1.0/lib/restclient/request.rb:339:in `new'
  /app/data/bundler/ruby/2.6.0/gems/rest-client-2.1.0/lib/restclient/request.rb:339:in `process_cookie_args!'
  /app/data/bundler/ruby/2.6.0/gems/rest-client-2.1.0/lib/restclient/request.rb:86:in `initialize'
  /app/data/bundler/ruby/2.6.0/gems/rest-client-2.1.0/lib/restclient/request.rb:63:in `new'
  /app/data/bundler/ruby/2.6.0/gems/rest-client-2.1.0/lib/restclient/request.rb:63:in `execute'
  /app/data/bundler/ruby/2.6.0/gems/rest-client-2.1.0/lib/restclient/resource.rb:51:in `get'
```

I tried to make that `const_missing` thread safe by using a mutex but I don't think it's possible because of circular dependencies.

A colleague of mine suggested that I leverage `autoload` which is thread safe.