### PR TITLE
Add 1.0.4 version to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.4 (2021-06-07)
 
 - Support Mozilla's cookie storage format up to version 7.
 


### PR DESCRIPTION
I've received update of `http-cookie` to 1.0.4 via dependabot, but seem there is no CHANGELOG entry for this release

Judging by changes between tag - unreleased changes is actually v1.0.4