### PR TITLE
Fix ArgumentError.

### DIFF
--- a/lib/http/cookie_jar/abstract_store.rb
+++ b/lib/http/cookie_jar/abstract_store.rb
@@ -18,7 +18,7 @@ class HTTP::CookieJar::AbstractStore
         require 'http/cookie_jar/%s_store' % symbol
         @@class_map.fetch(symbol)
       rescue LoadError, IndexError => e
-        raise IndexError, 'cookie store unavailable: %s, error: %s' % symbol.inspect, e.message
+        raise IndexError, 'cookie store unavailable: %s, error: %s' % [symbol.inspect, e.message]
       end
     end
 

--- a/test/test_http_cookie_jar.rb
+++ b/test/test_http_cookie_jar.rb
@@ -856,9 +856,10 @@ module TestHTTPCookieJar
       jar = HTTP::CookieJar.new(:store => :hash)
       assert_instance_of HTTP::CookieJar::HashStore, jar.store
 
-      assert_raises(ArgumentError) {
+      error = assert_raises(ArgumentError) {
         jar = HTTP::CookieJar.new(:store => :nonexistent)
       }
+      assert_equal 'cookie store unavailable: :nonexistent, error: cannot load such file -- http/cookie_jar/nonexistent_store', error.message
 
       jar = HTTP::CookieJar.new(:store => HTTP::CookieJar::HashStore.new)
       assert_instance_of HTTP::CookieJar::HashStore, jar.store


### PR DESCRIPTION
The following line in lib/http/cookie_jar/abstract_store.rb cause an ArgumentError:

```
raise IndexError, 'cookie store unavailable: %s, error: %s' % symbol.inspect, e.message
```

The parameters of the `%` operator must be passed as an array:

```
raise IndexError, 'cookie store unavailable: %s, error: %s' % [symbol.inspect, e.message]
```

Without this change:

```
> HTTP::Cookie::VERSION
 => "1.0.4" 

> HTTP::CookieJar.new(store: :unknown)
...
ArgumentError (too few arguments)
```

With this change:

```
> HTTP::Cookie::VERSION
 => "1.0.4" 

> HTTP::CookieJar.new(store: :unknown)
...
ArgumentError (cookie store unavailable: :unknown, error: cannot load such file -- http/cookie_jar/unknown_store)
```