### PR TITLE
Add support for SameSite=X & __Secure- / __Host- prefixes

### DIFF
--- a/lib/http/cookie/scanner.rb
+++ b/lib/http/cookie/scanner.rb
@@ -200,6 +200,8 @@ class HTTP::Cookie::Scanner < StringScanner
         when 'secure', 'httponly'
           # RFC 6265 5.2.5, 5.2.6
           avalue = true
+        when 'samesite'
+          avalue = avalue.downcase
         end
         attrs[aname] = avalue
       end until eos?

--- a/test/test_http_cookie.rb
+++ b/test/test_http_cookie.rb
@@ -810,6 +810,43 @@ class TestHTTPCookie < Test::Unit::TestCase
     assert_equal true, tld_cookie2.acceptable?
   end
 
+  def test_cookie_prefixes
+    url = URI 'https://www.example.com/'
+
+    # Must have secure flag set
+    tld_cookie1 = HTTP::Cookie.new(cookie_values(:name => '__Secure-Foo', :domain => '.example.com', :origin => url, :secure => false))
+    assert_equal false, tld_cookie1.acceptable?
+
+    url = URI 'http://www.example.com/'
+
+    # Must have secure flag & domain set
+    tld_cookie1 = HTTP::Cookie.new(cookie_values(:name => '__Secure-Foo', :secure => true, :domain => '.example.com', :origin => url))
+    assert_equal false, tld_cookie1.acceptable?
+
+    url = URI 'https://www.example.com/'
+
+    tld_cookie1 = HTTP::Cookie.new(cookie_values(:name => '__Secure-Foo', :secure => true, :domain => '.example.com', :origin => url))
+    assert_equal true, tld_cookie1.acceptable?
+
+    url = URI 'https://www.example.com/'
+
+    # Path must be /
+    tld_cookie1 = HTTP::Cookie.new(cookie_values(:name => '__Host-Foo', :path => '/admin/', :secure => true, :domain => 'www.example.com', :origin => url))
+    assert_equal false, tld_cookie1.acceptable?
+
+    # Domain must not be set
+    url = URI 'https://www.example.com/'
+
+    tld_cookie1 = HTTP::Cookie.new(cookie_values(:name => '__Host-Foo', :path => '', :secure => true, :domain => 'www.example.com', :origin => url))
+    assert_equal false, tld_cookie1.acceptable?
+
+    # Domain must not be set
+    url = URI 'https://www.example.com/'
+
+    tld_cookie1 = HTTP::Cookie.new(cookie_values(:name => '__Host-Foo', :path => '', :secure => true, :domain => 'www.example.com', :origin => url))
+    assert_equal false, tld_cookie1.acceptable?
+  end
+
   def test_fall_back_rules_for_local_domains
     url = URI 'http://www.example.local'
 
@@ -867,6 +904,29 @@ class TestHTTPCookie < Test::Unit::TestCase
     cookie_str = 'a=b; path=/foo'
     cookie = HTTP::Cookie.parse(cookie_str, uri).first
     assert '/foo', cookie.path
+  end
+
+  def test_same_site
+    cookie_str = 'a=b; SameSite=lax'
+    uri = URI.parse('http://example.com')
+
+    cookie = HTTP::Cookie.parse(cookie_str, uri).first
+    assert_equal 'lax', cookie.same_site
+
+    # SameSite=None requires the secure attribute to be set
+    cookie_str = 'a=b; SameSite=None'
+
+    cookie = HTTP::Cookie.new({:name => 'a', :value => 'bar', :same_site => 'none', :secure => false, :origin => uri})
+    assert_equal 'none', cookie.same_site
+    assert_equal false, cookie.acceptable?
+
+
+    # SameSite=None requires the secure attribute to be set
+    cookie_str = 'a=b; SameSite=Lax'
+
+    cookie = HTTP::Cookie.parse(cookie_str, uri).first
+    assert_equal 'lax', cookie.same_site
+    assert_equal "a=b; SameSite=lax", cookie.set_cookie_value
   end
 
   def test_domain_nil


### PR DESCRIPTION
Currently if a site specifies SameSite=None etc in the set-cookie header, it will be lost when HTTP::Cookie.parse parses it.

This PR adds support for parsing, preserving and restoring, via HTTP::Cookie#set_cookie_value the SameSite=X attribute.

It also respects the __Secure- and __Host- prefixes and rejects cookies that violate the spec.

Sources:
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#samesite_attribute
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#cookie_prefixes
 - https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-cookie-prefixes