### PR TITLE
Fix error formatting bug in HTTP::CookieJar::AbstractStore

### DIFF
--- a/lib/http/cookie_jar/abstract_store.rb
+++ b/lib/http/cookie_jar/abstract_store.rb
@@ -18,7 +18,7 @@ class HTTP::CookieJar::AbstractStore
         require 'http/cookie_jar/%s_store' % symbol
         @@class_map.fetch(symbol)
       rescue LoadError, IndexError => e
-        raise IndexError, 'cookie store unavailable: %s, error: %s' % symbol.inspect, e.message
+        raise IndexError, 'cookie store unavailable: %s, error: %s' % [symbol.inspect, e.message]
       end
     end
 

--- a/test/test_http_cookie_jar.rb
+++ b/test/test_http_cookie_jar.rb
@@ -9,6 +9,15 @@ module TestHTTPCookieJar
       }
     end
 
+    def test_nonexistent_store_in_config
+      assert_raise_with_message(
+        ArgumentError,
+        /cookie store unavailable: :nonexistent, error: cannot load .*nonexistent_store/
+      ) {
+        HTTP::CookieJar.new(store: :nonexistent)
+      }
+    end
+
     def test_erroneous_store
       Dir.mktmpdir { |dir|
         Dir.mkdir(File.join(dir, 'http'))


### PR DESCRIPTION
Before this patch is applied, the new test will fail:

```
     10:     end
     11: 
     12:     def test_nonexistent_store_in_config
  => 13:       assert_raise_with_message(
     14:         ArgumentError,
     15:         /cookie store unavailable: :nonexistent, error: cannot load .*nonexistent_store/
     16:       ) {
<ArgumentError> expected but was
<ArgumentError(<too few arguments>)
```

The bug seems to have been introduced a [while back](https://github.com/sparklemotion/http-cookie/commit/f828cf0319dc22797fad7d123b98121ba537f9c7).

This line:

```ruby
raise IndexError, 'cookie store unavailable: %s, error: %s' % symbol.inspect, e.message
```

Will be parsed as:
```lisp
(send nil :raise
  (const nil :IndexError)
  (send
    (str "cookie store unavailable: %s, error: %s") :%
    (send
      (send nil :symbol) :inspect))
  (send
    (send nil :e) :message))
```

This means that the message will be passed as an argument to the `IndexError` initializer instead of to `%`.

> If self contains multiple substitutions, object must be an Array or Hash containing the values to be substituted

[String#% docs](https://ruby-doc.org/3.2.1/String.html#method-i-25)