### PR TITLE
Replace thread-unsafe runtime requires with vanilla autoload

### DIFF
--- a/lib/http/cookie_jar.rb
+++ b/lib/http/cookie_jar.rb
@@ -6,26 +6,8 @@ require 'http/cookie'
 # any particular website.
 
 class HTTP::CookieJar
-  class << self
-    def const_missing(name)
-      case name.to_s
-      when /\A([A-Za-z]+)Store\z/
-        file = 'http/cookie_jar/%s_store' % $1.downcase
-      when /\A([A-Za-z]+)Saver\z/
-        file = 'http/cookie_jar/%s_saver' % $1.downcase
-      end
-      begin
-        require file
-      rescue LoadError
-        raise NameError, 'can\'t resolve constant %s; failed to load %s' % [name, file]
-      end
-      if const_defined?(name)
-        const_get(name)
-      else
-        raise NameError, 'can\'t resolve constant %s after loading %s' % [name, file]
-      end
-    end
-  end
+  autoload :AbstractStore, 'http/cookie_jar/abstract_store'
+  autoload :AbstractSaver, 'http/cookie_jar/abstract_saver'
 
   attr_reader :store
 

--- a/lib/http/cookie_jar/abstract_saver.rb
+++ b/lib/http/cookie_jar/abstract_saver.rb
@@ -2,29 +2,15 @@
 
 # An abstract superclass for all saver classes.
 class HTTP::CookieJar::AbstractSaver
-  class << self
-    @@class_map = {}
 
-    # Gets an implementation class by the name, optionally trying to
-    # load "http/cookie_jar/*_saver" if not found.  If loading fails,
-    # IndexError is raised.
-    def implementation(symbol)
-      @@class_map.fetch(symbol)
-    rescue IndexError
-      begin
-        require 'http/cookie_jar/%s_saver' % symbol
-        @@class_map.fetch(symbol)
-      rescue LoadError, IndexError
-        raise IndexError, 'cookie saver unavailable: %s' % symbol.inspect
-      end
-    end
-
-    def inherited(subclass) # :nodoc:
-      @@class_map[class_to_symbol(subclass)] = subclass
-    end
-
-    def class_to_symbol(klass) # :nodoc:
-      klass.name[/[^:]+?(?=Saver$|$)/].downcase.to_sym
+  def self.implementation(symbol)
+    case symbol
+    when :yaml
+      HTTP::CookieJar::YAMLSaver
+    when :cookiestxt
+      HTTP::CookieJar::CookiestxtSaver
+    else
+      raise IndexError, 'cookie saver unavailable: %s' % symbol.inspect
     end
   end
 
@@ -63,3 +49,6 @@ class HTTP::CookieJar::AbstractSaver
     # self
   end
 end
+
+require "http/cookie_jar/yaml_saver"
+require "http/cookie_jar/cookiestxt_saver"

--- a/lib/http/cookie_jar/abstract_store.rb
+++ b/lib/http/cookie_jar/abstract_store.rb
@@ -6,28 +6,17 @@ class HTTP::CookieJar::AbstractStore
   include MonitorMixin
 
   class << self
-    @@class_map = {}
 
-    # Gets an implementation class by the name, optionally trying to
-    # load "http/cookie_jar/*_store" if not found.  If loading fails,
-    # IndexError is raised.
+    # Gets an implementation class by the name.
     def implementation(symbol)
-      @@class_map.fetch(symbol)
-    rescue IndexError
-      begin
-        require 'http/cookie_jar/%s_store' % symbol
-        @@class_map.fetch(symbol)
-      rescue LoadError, IndexError => e
-        raise IndexError, 'cookie store unavailable: %s, error: %s' % symbol.inspect, e.message
+      case symbol
+      when :hash
+        HTTP::CookieJar::HashStore
+      when :mozilla
+        HTTP::CookieJar::MozillaStore
+      else
+        raise IndexError, 'cookie store unavailable: %s' % symbol.inspect
       end
-    end
-
-    def inherited(subclass) # :nodoc:
-      @@class_map[class_to_symbol(subclass)] = subclass
-    end
-
-    def class_to_symbol(klass) # :nodoc:
-      klass.name[/[^:]+?(?=Store$|$)/].downcase.to_sym
     end
   end
 
@@ -122,3 +111,6 @@ class HTTP::CookieJar::AbstractStore
     # self
   end
 end
+
+require 'http/cookie_jar/hash_store'
+require 'http/cookie_jar/mozilla_store'

--- a/test/test_http_cookie_jar.rb
+++ b/test/test_http_cookie_jar.rb
@@ -10,17 +10,8 @@ module TestHTTPCookieJar
     end
 
     def test_erroneous_store
-      Dir.mktmpdir { |dir|
-        Dir.mkdir(File.join(dir, 'http'))
-        Dir.mkdir(File.join(dir, 'http', 'cookie_jar'))
-        rb = File.join(dir, 'http', 'cookie_jar', 'erroneous_store.rb')
-        File.open(rb, 'w').close
-        $LOAD_PATH.unshift(dir)
-
-        assert_raises(NameError) {
-          HTTP::CookieJar::ErroneousStore
-        }
-        assert($LOADED_FEATURES.any? { |file| FileTest.identical?(file, rb) })
+      assert_raises(NameError) {
+        HTTP::CookieJar::ErroneousStore
       }
     end
 
@@ -31,17 +22,8 @@ module TestHTTPCookieJar
     end
 
     def test_erroneous_saver
-      Dir.mktmpdir { |dir|
-        Dir.mkdir(File.join(dir, 'http'))
-        Dir.mkdir(File.join(dir, 'http', 'cookie_jar'))
-        rb = File.join(dir, 'http', 'cookie_jar', 'erroneous_saver.rb')
-        File.open(rb, 'w').close
-        $LOAD_PATH.unshift(dir)
-
-        assert_raises(NameError) {
-          HTTP::CookieJar::ErroneousSaver
-        }
-        assert($LOADED_FEATURES.any? { |file| FileTest.identical?(file, rb) })
+      assert_raises(NameError) {
+        HTTP::CookieJar::ErroneousSaver
       }
     end
   end


### PR DESCRIPTION
Dynamically requiring implementations at runtime in this way is not safe in a multithreaded program, even in MRI with the GIL. We can simplify this while retaining identical performance by just using autoload and turning the `@@class_map` into a simple case statement.

I'm not sure dynamic selection of the implementation is even really necessary but I left it in to avoid changing too much in one PR.

Fixes https://github.com/sparklemotion/http-cookie/issues/27