### PR TITLE
Allow non-RFC 3986-compliant URLs

### DIFF
--- a/lib/http/cookie_jar.rb
+++ b/lib/http/cookie_jar.rb
@@ -156,8 +156,8 @@ class HTTP::CookieJar
     block_given? or return enum_for(__method__, uri)
 
     if uri
-      uri = URI(uri)
-      return self unless URI::HTTP === uri && uri.host
+      uri = HTTP::Cookie.parse_uri(uri)
+      return self unless ["http", "https"].include?(uri.scheme.downcase) && uri.host
     end
 
     @store.each(uri, &block)


### PR DESCRIPTION
HTTP::Cookie uses [uri](https://github.com/ruby/uri) which parses URLs strictly according to RFC 3986.

Many HTTP clients allow requesting URLs which are not compliant with RFC 3986. In practice, this usually works. E.g. cURL supports a wider range of URLs described as [“RFC 3986 plus”](https://github.com/curl/curl/blob/master/docs/URL-SYNTAX.md). Apart from 8-bit characters, the requested URL is more or less passed on verbatim to the server, even if it contains characters not permitted by RFC 3986. The same applies to web browsers.

Trying to “fix” non-compliant URLs is tricky. See e.g. https://github.com/httprb/http/pull/758.

In the spirit of [Postel's law](https://en.wikipedia.org/wiki/Robustness_principle) _(“be conservative in what you do, be liberal in what you accept from others”)_, I suggest HTTP::Cookie accepts a wider range of URLs.

With this PR, HTTP::Cookie does not parse URLs from strings if they are represented by an `URI`-like object, e.g. [`HTTP::URI`](https://github.com/httprb/http/blob/main/lib/http/uri.rb) from http.rb or [`Addressable::URI`](https://github.com/sporkmonger/addressable/blob/main/lib/addressable/uri.rb). This also reduces the work connected with converting a `URI`-like object to a string and parsing it back into another `URI` object.

Fixes https://github.com/sparklemotion/http-cookie/issues/24.