### PR TITLE
quash ruby 3.4 warnings

### DIFF
--- a/lib/http/cookie.rb
+++ b/lib/http/cookie.rb
@@ -1,4 +1,5 @@
 # :markup: markdown
+# frozen_string_literal: true
 require 'http/cookie/version'
 require 'http/cookie/uri_parser'
 require 'time'
@@ -425,7 +426,7 @@ class HTTP::Cookie
   # Returns the domain, with a dot prefixed only if the domain flag is
   # on.
   def dot_domain
-    @for_domain ? '.' << @domain : @domain
+    @for_domain ? (+'.') << @domain : @domain
   end
 
   # Returns the domain attribute value as a DomainName object.
@@ -595,7 +596,7 @@ class HTTP::Cookie
   # Returns a string for use in the Cookie header, i.e. `name=value`
   # or `name="value"`.
   def cookie_value
-    "#{@name}=#{Scanner.quote(@value)}"
+    +"#{@name}=#{Scanner.quote(@value)}"
   end
   alias to_s cookie_value
 

--- a/lib/http/cookie/scanner.rb
+++ b/lib/http/cookie/scanner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'http/cookie'
 require 'strscan'
 require 'time'
@@ -23,7 +24,7 @@ class HTTP::Cookie::Scanner < StringScanner
   class << self
     def quote(s)
       return s unless s.match(RE_BAD_CHAR)
-      '"' << s.gsub(/([\\"])/, "\\\\\\1") << '"'
+      (+'"') << s.gsub(/([\\"])/, "\\\\\\1") << '"'
     end
   end
 
@@ -32,7 +33,7 @@ class HTTP::Cookie::Scanner < StringScanner
   end
 
   def scan_dquoted
-    ''.tap { |s|
+    (+'').tap { |s|
       case
       when skip(/"/)
         break
@@ -51,7 +52,7 @@ class HTTP::Cookie::Scanner < StringScanner
   end
 
   def scan_value(comma_as_separator = false)
-    ''.tap { |s|
+    (+'').tap { |s|
       case
       when scan(/[^,;"]+/)
         s << matched

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,7 +7,7 @@ module Test
   module Unit
     module Assertions
       def assert_warn(pattern, message = nil, &block)
-        class << (output = "")
+        class << (output = +"")
           alias write <<
         end
         stderr, $stderr = $stderr, output

--- a/test/test_http_cookie.rb
+++ b/test/test_http_cookie.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: false
 require File.expand_path('helper', File.dirname(__FILE__))
 require 'psych' if !defined?(YAML) && RUBY_VERSION == "1.9.2"
 require 'yaml'
@@ -757,7 +758,7 @@ class TestHTTPCookie < Test::Unit::TestCase
     assert_equal 12, cookie.max_age
 
     cookie.max_age = -3
-    assert_equal -3, cookie.max_age
+    assert_equal(-3, cookie.max_age)
   end
 
   def test_session

--- a/test/test_http_cookie.rb
+++ b/test/test_http_cookie.rb
@@ -1016,7 +1016,7 @@ class TestHTTPCookie < Test::Unit::TestCase
           'https://www.example.com/dir2/test.html',
         ]
       },
-      HTTP::Cookie.parse('a4=b; domain=example.com; path=/dir2/',
+      HTTP::Cookie.parse('a3=b; domain=example.com; path=/dir2/',
         URI('http://example.com/dir/file.html')).first => {
         true => [
           'https://example.com/dir2/test.html',
@@ -1044,7 +1044,7 @@ class TestHTTPCookie < Test::Unit::TestCase
           'file:///dir2/test.html',
         ]
       },
-      HTTP::Cookie.parse('a4=b; secure',
+      HTTP::Cookie.parse('a5=b; secure',
         URI('https://example.com/dir/file.html')).first => {
         true => [
           'https://example.com/dir/test.html',
@@ -1056,7 +1056,7 @@ class TestHTTPCookie < Test::Unit::TestCase
           'file:///dir2/test.html',
         ]
       },
-      HTTP::Cookie.parse('a5=b',
+      HTTP::Cookie.parse('a6=b',
         URI('https://example.com/')).first => {
         true => [
           'https://example.com',
@@ -1065,7 +1065,7 @@ class TestHTTPCookie < Test::Unit::TestCase
           'file:///',
         ]
       },
-      HTTP::Cookie.parse('a6=b; path=/dir',
+      HTTP::Cookie.parse('a7=b; path=/dir',
         'http://example.com/dir/file.html').first => {
         true => [
           'http://example.com/dir',

--- a/test/test_http_cookie_jar.rb
+++ b/test/test_http_cookie_jar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require File.expand_path('helper', File.dirname(__FILE__))
 require 'tmpdir'
 


### PR DESCRIPTION
- add `frozen-string-literal: true` to some lib files
  - and explicitly make some strings mutable
- add `frozen-string-literal: false` to some test files
- add parenthesis in one test that was generating a warning
