### PR TITLE
Update cookie.rb to handle situations when expires is a DateTime object

### DIFF
--- a/lib/http/cookie.rb
+++ b/lib/http/cookie.rb
@@ -89,7 +89,7 @@ class HTTP::Cookie
 
   # The Expires attribute value as a Time object.
   #
-  # The setter method accepts a Time object, a string representation
+  # The setter method accepts a Time / DateTime object, a string representation
   # of date/time that Time.parse can understand, or `nil`.
   #
   # Setting this value resets #max_age to nil.  When #max_age is
@@ -493,6 +493,8 @@ class HTTP::Cookie
   def expires= t
     case t
     when nil, Time
+    when DateTime
+      t = t.to_time
     else
       t = Time.parse(t)
     end

--- a/test/test_http_cookie.rb
+++ b/test/test_http_cookie.rb
@@ -717,8 +717,22 @@ class TestHTTPCookie < Test::Unit::TestCase
   end
 
   def test_expiration
-    cookie = HTTP::Cookie.new(cookie_values)
+    expires = Time.now + 86400
+    cookie = HTTP::Cookie.new(cookie_values(expires: expires))
 
+    assert_equal(expires, cookie.expires)
+    assert_equal false, cookie.expired?
+    assert_equal true, cookie.expired?(cookie.expires + 1)
+    assert_equal false, cookie.expired?(cookie.expires - 1)
+    cookie.expire!
+    assert_equal true, cookie.expired?
+  end
+
+  def test_expiration_using_datetime
+    expires = DateTime.now + 1
+    cookie = HTTP::Cookie.new(cookie_values(expires: expires))
+
+    assert_equal(expires.to_time, cookie.expires)
     assert_equal false, cookie.expired?
     assert_equal true, cookie.expired?(cookie.expires + 1)
     assert_equal false, cookie.expired?(cookie.expires - 1)


### PR DESCRIPTION
As mentioned in the commit detailed message

> The standard Selenium WebDriver response is to return an object which has an expiry in datetime format.
In order to most effectively work with Selenium, and to provide the smallest barrier possible, co-erce the DateTime object into a Time object and then store it as a HTTP Cookie

The reason for this change is that I have started working with cookies now and need a way of quickly storing them as they have nice uses for other tests and then call them back. I found this library didn't work well with the standard cookies obtained using the W3C conformant endpoints

- See [HERE](https://www.selenium.dev/documentation/webdriver/interactions/cookies/) for more info on working with cookies with the Selenium level API
- See [HERE](https://www.w3.org/TR/webdriver1/#get-named-cookie) for w3c spec for cookies specifically `#get_cookie`
