### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next (unreleased)
 
 - Implement `Cookie#to_h`. (#55) @luke-hill @flavorjones
+- Reduce gem size by excluding test files
 
 ## 1.0.8 (2024-12-05)
 

--- a/http-cookie.gemspec
+++ b/http-cookie.gemspec
@@ -18,7 +18,11 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/sparklemotion/http-cookie"
   gem.license       = "MIT"
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files lib`.split($/) + [
+    'CHANGELOG.md',
+    'LICENSE.txt',
+    'README.md',
+  ]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
```bash
$ gem build -o before

$ git switch reduce-gem-size

$ gem build -o after

$ du -sh before after
 40K	before
 28K	after
 ```
 
 |        | before | after |     saved                     |
|--------|--------|-------|--------------------------|
| size   | 40K    | 28K   | -12K  ($\textcolor{green}{⏷}$ -30.00%) |