### PR TITLE
Add `#to_h` to cookie.rb

### DIFF
--- a/lib/http/cookie.rb
+++ b/lib/http/cookie.rb
@@ -655,6 +655,11 @@ class HTTP::Cookie
   end
   include Comparable
 
+  # Hash serialization helper for use back into other libraries (Like Selenium)
+  def to_h
+    PERSISTENT_PROPERTIES.each_with_object({}) { |property, hash| [property.to_sym] => instance_variable_get("@#{property}") }
+  end
+
   # YAML serialization helper for Syck.
   def to_yaml_properties
     PERSISTENT_PROPERTIES.map { |name| "@#{name}" }

--- a/lib/http/cookie.rb
+++ b/lib/http/cookie.rb
@@ -657,7 +657,7 @@ class HTTP::Cookie
 
   # Hash serialization helper for use back into other libraries (Like Selenium)
   def to_h
-    PERSISTENT_PROPERTIES.each_with_object({}) { |property, hash| [property.to_sym] => instance_variable_get("@#{property}") }
+    PERSISTENT_PROPERTIES.each_with_object({}) { |property, hash| hash[property.to_sym] = instance_variable_get("@#{property}") }
   end
 
   # YAML serialization helper for Syck.

--- a/test/test_http_cookie.rb
+++ b/test/test_http_cookie.rb
@@ -1169,29 +1169,44 @@ class TestHTTPCookie < Test::Unit::TestCase
     assert_equal true,  HTTP::Cookie.path_match?('/admin', '/admin/index')
   end
 
-  def test_to_h_coercion
+  def test_to_h
     now = Time.now
-    cookie = HTTP::Cookie.new(cookie_values.merge({ expires: now, max_age: 3600, created_at: now, accessed_at: now }))
 
-    cookie.keys.each { |key| assert_equal key.class, Symbol }
-    assert_equal cookie.keys.map(&:to_s), PERSISTENT_PROPERTIES
-
+    cookie = HTTP::Cookie.new(cookie_values.merge({ max_age: 3600, created_at: now, accessed_at: now }))
     expected_hash =
       {
+        accessed_at: now,
+        created_at: now,
+        domain: 'rubyforge.org',
+        expires: nil,
+        for_domain: true,
+        httponly: cookie.httponly?,
+        max_age: 3600,
         name: 'Foo',
-        value: 'Bar',
         path: '/',
+        secure: cookie.secure?,
+        value: 'Bar',
+      }
+
+    assert_equal expected_hash, cookie.to_h
+
+    # exercise expires/max_age interaction
+    cookie = HTTP::Cookie.new(cookie_values.merge({ expires: now, created_at: now, accessed_at: now }))
+    expected_hash =
+      {
+        accessed_at: now,
+        created_at: now,
+        domain: 'rubyforge.org',
         expires: now,
         for_domain: true,
-        domain: 'rubyforge.org',
-        origin: 'http://rubyforge.org/',
-        secure: true,
-        httponly: true,
-        max_age: 3600,
-        created_at: now,
-        accessed_at: now
+        httponly: cookie.httponly?,
+        max_age: nil,
+        name: 'Foo',
+        path: '/',
+        secure: cookie.secure?,
+        value: 'Bar',
       }
-        
-    assert_equal cookie.to_h, expected_hash
+
+    assert_equal expected_hash, cookie.to_h
   end
 end

--- a/test/test_http_cookie.rb
+++ b/test/test_http_cookie.rb
@@ -1168,4 +1168,30 @@ class TestHTTPCookie < Test::Unit::TestCase
     assert_equal true,  HTTP::Cookie.path_match?('/admin', '/admin/')
     assert_equal true,  HTTP::Cookie.path_match?('/admin', '/admin/index')
   end
+
+  def test_to_h_coercion
+    now = Time.now
+    cookie = HTTP::Cookie.new(cookie_values.merge({ expires: now, max_age: 3600, created_at: now, accessed_at: now }))
+
+    cookie.keys.each { |key| assert_equal key.class, Symbol }
+    assert_equal cookie.keys.map(&:to_s), PERSISTENT_PROPERTIES
+
+    expected_hash =
+      {
+        name: 'Foo',
+        value: 'Bar',
+        path: '/',
+        expires: now,
+        for_domain: true,
+        domain: 'rubyforge.org',
+        origin: 'http://rubyforge.org/',
+        secure: true,
+        httponly: true,
+        max_age: 3600,
+        created_at: now,
+        accessed_at: now
+      }
+        
+    assert_equal cookie.to_h, expected_hash
+  end
 end


### PR DESCRIPTION
I'm aware this doesn't have tests. But I'm writing this in Github code style.

@flavorjones is this about the right way to do it again? WDYT? is this acceptable>

This allows me to take the HTTP::Cookie I'm storing locally in Jars and then write it back to selenium to generate new cookies copied from a previous cache