### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "automerge"
     groups:
@@ -16,6 +18,8 @@ updates:
     target-branch: "v1.1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "automerge"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           advanced-security: false
 
   ruby-versions:
-    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master # zizmor: ignore[unpinned-uses] -- trusted ruby-org reusable workflow; @master required to keep the Ruby version matrix current
     with:
       engine: cruby-jruby
       min_version: 3.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,23 @@ on:
       - "*"
 
 jobs:
+  lint-actions:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.11
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@v0.5.2
+        with:
+          advanced-security: false
+
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,15 @@ on:
     branches:
       - "*"
 
+permissions: {}
+
 jobs:
   lint-actions:
     name: GitHub Actions audit
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -28,6 +33,7 @@ jobs:
           advanced-security: false
 
   ruby-versions:
+    permissions: {}
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master # zizmor: ignore[unpinned-uses] -- trusted ruby-org reusable workflow; @master required to keep the Ruby version matrix current
     with:
       engine: cruby-jruby
@@ -35,6 +41,8 @@ jobs:
 
   test:
     needs: ruby-versions
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +72,7 @@ jobs:
     if: always()
     needs: test
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check test results
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
     permissions: {}
     steps:
       - name: Check test results
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
+          if [ "$TEST_RESULT" != "success" ]; then
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up ruby and bundle
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.11
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0.5.2
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           advanced-security: false
 
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up ruby and bundle
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true

--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # zizmor: ignore[cache-poisoning] -- GitHub Actions caches are ref-isolated; a PR/fork cache cannot be restored by this tag-push release build # v1.302.0
         with:
           ruby-version: ruby
           bundler-cache: true

--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -28,6 +28,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # zizmor: ignore[cache-poisoning] -- GitHub Actions caches are ref-isolated; a PR/fork cache cannot be restored by this tag-push release build # v1.302.0

--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -5,8 +5,7 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   push:


### PR DESCRIPTION
This hardens the GitHub Actions workflows against the vulnerability classes that [zizmor](https://docs.zizmor.sh/) audits. It handles the cache-poisoning concern differently from [#76](https://github.com/sparklemotion/http-cookie/pull/76), see thread in that PR.

## Changes

- A `lint-actions` job in `ci.yml` runs actionlint and zizmor on every push and pull request, so workflow regressions surface in CI.
- Both `github-actions` entries in `dependabot.yml` gain a seven-day cooldown, which matches the minimum age used when pinning.
- Every action is pinned to a commit SHA with `pinact`. The `ruby/actions` `ruby_versions.yml` reusable workflow stays on `@master` so that the Ruby version matrix remains current, and an inline comment records why that reference is not pinned.
- `GITHUB_TOKEN` permissions are scoped per job. Both workflows deny all permissions at the top level and grant each job only the permissions it needs.
- Every checkout sets `persist-credentials: false`. The release job remains correct because `rubygems/release-gem` configures its own git credential cache for the tag push.

## Cache poisoning in the release workflow

I kept `bundler-cache: true` in `push_gem.yml` and suppressed the zizmor `cache-poisoning` finding rather than disabling the cache. GitHub Actions caches are isolated by git ref. A cache created by a pull request lives in the `refs/pull/<n>/merge` scope and can only be restored by re-runs of that pull request, so nothing a fork or pull request does can reach the cache that this tag-push release build restores. The inline suppression comment records this reasoning.

## Verification

zizmor reports no findings under both the default and pedantic personas, and actionlint is clean.
