### PR TITLE
Pin rbs to >= 4.1.0.pre.2 on JRuby to fix CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in http-cookie.gemspec
 gemspec
+
+# rdoc depends on rbs, which ships no java-platform gem before 4.1.0.pre.2, so on
+# JRuby bundler tries to compile rbs's native extension and fails.
+# See https://github.com/ruby/rdoc/issues/1746
+gem 'rbs', '>= 4.1.0.pre.2' if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
The `jruby` and `jruby-head` CI jobs fail during `bundle install`:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
...
An error occurred while installing rbs (4.0.3), and Bundler cannot continue.
```

The `rdoc` development dependency pulls in `rbs`. Before version 4.1.0.pre.2, `rbs` shipped only a C-extension gem, so `bundle install` tries to compile a native extension. That fails on the JRuby runner because it has no C toolchain.

This pins `rbs` to `>= 4.1.0.pre.2` on JRuby only, where `rbs` publishes a `java`-platform gem with no native extension to build. Other Rubies are unaffected and continue to resolve `rdoc` and `rbs` as before.

See https://github.com/ruby/rdoc/issues/1746.
