### PR TITLE
Give copied hash stores independent monitors

### DIFF
--- a/lib/http/cookie_jar/hash_store.rb
+++ b/lib/http/cookie_jar/hash_store.rb
@@ -47,6 +47,8 @@ class HTTP::CookieJar
 
     # The copy constructor.  This store class supports cloning.
     def initialize_copy(other)
+      super
+      mon_initialize
       @jar = Marshal.load(Marshal.dump(other.instance_variable_get(:@jar)))
     end
 


### PR DESCRIPTION
HashStore deep-copies cookie data but retains MonitorMixin state, so holding the original store lock can block the copy. Reinitialize the monitor before copying data.

Verification: distinct-monitor, cross-block, data, and CookieJar copy model passes; full suite 144 tests / 2,870 assertions, zero failures/errors. Source-only patch; no tests included.