### PR TITLE
Serialize session cookies with zero expiry

### DIFF
--- a/lib/http/cookie_jar/cookiestxt_saver.rb
+++ b/lib/http/cookie_jar/cookiestxt_saver.rb
@@ -59,7 +59,7 @@ class HTTP::CookieJar::CookiestxtSaver < HTTP::CookieJar::AbstractSaver
         @for_domain ? True : False,
         @path,
         @secure ? True : False,
-        expires.to_i,
+        expires ? expires.to_i : 0,
         @name,
         @value
       ]


### PR DESCRIPTION
cookies.txt uses zero as its session-cookie expiry sentinel, but the saver calls to_i on nil for session cookies. Emit zero explicitly when expires is absent.

Verification: save and load session round trip passes; full suite 144 tests / 2,870 assertions, zero failures/errors. Source-only patch; no tests included.