### PR TITLE
Make SQLite schema upgrades transactional

### DIFF
--- a/lib/http/cookie_jar/mozilla_store.rb
+++ b/lib/http/cookie_jar/mozilla_store.rb
@@ -65,6 +65,10 @@ class HTTP::CookieJar
         @db.execute(*args, &block)
       end
 
+      def transaction(&block)
+        @db.transaction(&block)
+      end
+
       def create_function(*args, &block)
         @db.create_function(*args, &block)
       end
@@ -248,6 +252,10 @@ class HTTP::CookieJar
     end
 
     def upgrade_database
+      @db.transaction { upgrade_database! }
+    end
+
+    def upgrade_database!
       loop {
         case schema_version
         when nil, 0


### PR DESCRIPTION
Run the complete SQLite schema upgrade inside one transaction. A failure during v4 to v5 currently leaves user_version advanced, an old table, and an empty replacement; the transaction preserves the original v4 database and allows a clean retry to v7.

Verification: injected-failure rollback and retry model passes; full suite 144 tests / 2,870 assertions, zero failures/errors. Source-only patch; no tests included.